### PR TITLE
README: Fix link to license text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Maximaleft
 
-[Maximaleft](./maximaleft.md) the strongest copyleft software license possible.
+[Maximaleft](./license.md) the strongest copyleft software license possible.
 
 Maximaleft is also a [flipped form](https://flippedform.com) in everyday English.  If something doesn't make sense, that's the terms' fault, not yours.  Please [open an issue on GitHub](https://github.com/kemitchell/maximaleft/issues/new) so we can fix it.


### PR DESCRIPTION
Nice license!

P.S. Maybe a colon after the link? `Maximaleft: the strongest copyleft software license possible.`
